### PR TITLE
fix: incorrect formula output type enum value

### DIFF
--- a/Onspring.API.SDK.Tests/TestServer/Controllers/FieldsController.cs
+++ b/Onspring.API.SDK.Tests/TestServer/Controllers/FieldsController.cs
@@ -24,7 +24,7 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
         [HttpPost("batch-get")]
         public IActionResult GetBatchById([FromBody, MinLength(1)] int[] fieldIds)
         {
-            var getFieldsResponse = new GetFieldsResponse
+            var getFieldsResponse = new
             {
                 Items = GetTestFields()
             };
@@ -38,7 +38,7 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
             pagingRequest ??= new PagingRequest();
 
             var items = GetTestFields();
-            var getResponse = new GetPagedFieldsResponse
+            var getResponse = new
             {
                 Items = items.Take(pagingRequest.PageSize).ToList(),
                 PageNumber = pagingRequest.PageNumber,
@@ -49,33 +49,33 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
             return Ok(getResponse);
         }
 
-        private static List<Field> GetTestFields()
+        private static List<object> GetTestFields()
         {
-            return new List<Field>
+            return new List<object>
             {
-                new Field
+                new
                 {
                     AppId = 1,
                     Id = 1,
                     IsRequired = true,
                     IsUnique  = true,
                     Name = "Regular field",
-                    Status = Enums.FieldStatus.Enabled,
-                    Type = Enums.FieldType.Text,
+                    Status = "Enabled",
+                    Type = "Text",
                 },
-                new ListField
+                new
                 {
                     AppId = 1,
                     Id = 1,
                     IsRequired = true,
                     IsUnique  = false,
                     Name = "List field",
-                    Status = Enums.FieldStatus.Enabled,
-                    Type = Enums.FieldType.List,
-                    Multiplicity = Enums.Multiplicity.MultiSelect,
-                    Values = new List<ListValue>
+                    Status = "Enabled",
+                    Type = "List",
+                    Multiplicity = "MultiSelect",
+                    Values = new List<object>
                     {
-                        new ListValue
+                        new
                         {
                             Color = "#ffffff",
                             Id = Guid.NewGuid(),
@@ -83,7 +83,7 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
                             NumericValue = 1m,
                             SortOrder = 1,
                         },
-                        new ListValue
+                        new
                         {
                             Color = "#ffffff",
                             Id = Guid.NewGuid(),
@@ -93,38 +93,38 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
                         },
                     },
                 },
-                new FormulaField
+                new
                 {
                     AppId = 1,
                     Id = 1,
                     IsRequired = true,
                     IsUnique  = false,
                     Name = "List field",
-                    Status = Enums.FieldStatus.Enabled,
-                    Type = Enums.FieldType.Formula,
-                    OutputType = Enums.FormulaOutputType.Date,
-                    Values = new List<ListValue>
+                    Status = "Enabled",
+                    Type = "Formula",
+                    OutputType = "List",
+                    Values = new List<object>
                     {
-                        new ListValue
+                        new
                         {
                             Color = "#ffffff",
                             Id = Guid.NewGuid(),
-                            Name = "First Formula",
+                            Name = "List Value",
                             NumericValue = 1m,
                             SortOrder = 1,
                         },
                     },
                 },
-                new ReferenceField
+                new
                 {
                     AppId = 1,
                     Id = 1,
                     IsRequired = true,
                     IsUnique  = false,
                     Name = "List field",
-                    Status = Enums.FieldStatus.Enabled,
-                    Type = Enums.FieldType.Reference,
-                    Multiplicity = Enums.Multiplicity.SingleSelect,
+                    Status = "Enabled",
+                    Type = "Reference",
+                    Multiplicity = "SingleSelect",
                 }
             };
         }

--- a/Onspring.API.SDK.Tests/TestServer/Controllers/FieldsController.cs
+++ b/Onspring.API.SDK.Tests/TestServer/Controllers/FieldsController.cs
@@ -1,10 +1,13 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 using Onspring.API.SDK.Models;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Xml.Linq;
 
 namespace Onspring.API.SDK.Tests.TestServer.Controllers
 {
@@ -97,9 +100,9 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
                 {
                     AppId = 1,
                     Id = 1,
-                    IsRequired = true,
+                    IsRequired = false,
                     IsUnique  = false,
-                    Name = "List field",
+                    Name = "List Formula Field",
                     Status = "Enabled",
                     Type = "Formula",
                     OutputType = "List",
@@ -114,6 +117,42 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
                             SortOrder = 1,
                         },
                     },
+                },
+                new
+                {
+                    AppId = 1,
+                    Id = 1,
+                    IsRequired = false,
+                    IsUnique  = false,
+                    Name = "Date/Time Formula Field",
+                    Status = "Enabled",
+                    Type = "Formula",
+                    OutputType = "DateAndTime",
+                    Values = new List<object>(),
+                },
+                new
+                {
+                    AppId = 1,
+                    Id = 1,
+                    IsRequired = false,
+                    IsUnique  = false,
+                    Name = "Numeric Formula Field",
+                    Status = "Enabled",
+                    Type = "Formula",
+                    OutputType = "Numeric",
+                    Values = new List<object>(),
+                },
+                new
+                {
+                    AppId = 1,
+                    Id = 1,
+                    IsRequired = false,
+                    IsUnique  = false,
+                    Name = "Text Formula Field",
+                    Status = "Enabled",
+                    Type = "Formula",
+                    OutputType = "Text",
+                    Values = new List<object>(),
                 },
                 new
                 {

--- a/Onspring.API.SDK.Tests/TestServer/Controllers/FieldsController.cs
+++ b/Onspring.API.SDK.Tests/TestServer/Controllers/FieldsController.cs
@@ -1,17 +1,14 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
 using Onspring.API.SDK.Models;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace Onspring.API.SDK.Tests.TestServer.Controllers
 {
-    [ApiController, Route("[controller]")]
+  [ApiController, Route("[controller]")]
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Just a test controller. Not an API that gets shipped.")]
     [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "Just a test controller. Not an API that gets shipped.")]
@@ -105,7 +102,7 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
                     Name = "List Formula Field",
                     Status = "Enabled",
                     Type = "Formula",
-                    OutputType = "List",
+                    OutputType = "ListValue",
                     Values = new List<object>
                     {
                         new

--- a/Onspring.API.SDK/Enums/FormulaOutputType.cs
+++ b/Onspring.API.SDK/Enums/FormulaOutputType.cs
@@ -11,7 +11,7 @@ namespace Onspring.API.SDK.Enums
     public enum FormulaOutputType
     {
         Text = 0,
-        Number = 1,
+        Numeric = 1,
         DateAndTime = 2,
         List = 3,
     }

--- a/Onspring.API.SDK/Enums/FormulaOutputType.cs
+++ b/Onspring.API.SDK/Enums/FormulaOutputType.cs
@@ -13,6 +13,6 @@ namespace Onspring.API.SDK.Enums
         Text = 0,
         Numeric = 1,
         DateAndTime = 2,
-        List = 3,
+        ListValue = 3,
     }
 }

--- a/Onspring.API.SDK/Enums/FormulaOutputType.cs
+++ b/Onspring.API.SDK/Enums/FormulaOutputType.cs
@@ -12,7 +12,7 @@ namespace Onspring.API.SDK.Enums
     {
         Text = 0,
         Number = 1,
-        Date = 2,
+        DateAndTime = 2,
         List = 3,
     }
 }


### PR DESCRIPTION
### **_Related Issues:_**
+ Closes #9 
+ Closes #10 
+ Closes #12 

### **_Summary of Changes:_**
When retrieving a formula field from the `Onspring API` this type of field can contain four possible values for it's `outputType` property - `DateAndTime`, `Numeric`, `Text`, `ListValue`.

The `Onspring.Api.Sdk` when retrieving these formula fields is attempting to deserialize these formula field's `outputType` property to one of four named values in the `FormulaOutputType.cs` enum.

However three of the named values in the `FormulaOutputType.cs` enum are named incorrectly causing the deserialization to fail. Specifically these are the `Date`, `List`, and `Number` values. These values should instead be named `DateAndTime`, `ListValue` and `Numeric`, respectively.

I've made these changes in the branch associated with this PR and confirmed locally that making this name change allows the deserialization to complete successfully.

I also ran the tests locally after making the changes and all tests passed.

#### **_NOTE EXPLAINING TEST CHANGES IN `FieldsController.cs`_**: 
Prior to making these changes I did amend the data returned by the `FieldsController.cs` in the test server to allow me to return a collection of anonymous objects that includes a field data set which contains a formula field with each possible output type.

Doing this allowed me to cause the `GetFieldsAsync` and `GetFieldsForAppAsync` tests in `OnspringClientFieldTests` to fail and reproduce the underlying deserialization issue caused by the incorrectly named enum values.

Before I made these changes to the `FieldsController.cs` the data returned by the `FieldsController.cs` methods was produced using concrete classes and enums from the `Onspring.Api.Sdk` itself. Happy to revert these changes if what I did is not desirable, but it seemed like using concrete classes and enums from the `Onspring.Api.Sdk` itself to produce the responses to the tests could prevent you from finding issues like this when deserializing the response data to these same classes and enums.

