### PR TITLE
fix: validate content type prior to deserialization

### DIFF
--- a/Onspring.API.SDK.Tests/TestServer/Controllers/ErrorResponseController.cs
+++ b/Onspring.API.SDK.Tests/TestServer/Controllers/ErrorResponseController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Onspring.API.SDK.Tests.TestServer.Controllers
+{
+    [ApiController, Route("[controller]")]
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Just a test controller. Not an API that gets shipped.")]
+    [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "Just a test controller. Not an API that gets shipped.")]
+    public class ErrorResponseController : ControllerBase
+    {
+        [HttpGet("non-json-unauthorized")]
+        public IActionResult NonJsonUnauthorized()
+        {
+            var htmlContent = "<html><body>Unauthorized</body></html>";
+            return new ContentResult
+            {
+                Content = htmlContent,
+                ContentType = "text/html; charset=utf-8",
+                StatusCode = 401
+            };
+        }
+
+        [HttpGet("non-json-forbidden")]
+        public IActionResult NonJsonForbidden()
+        {
+            var htmlContent = "<html><body>Forbidden</body></html>";
+            return new ContentResult
+            {
+                Content = htmlContent,
+                ContentType = "text/html; charset=utf-8",
+                StatusCode = 403
+            };
+        }
+
+        [HttpGet("non-json-not-found")]
+        public IActionResult NonJsonNotFound()
+        {
+            var htmlContent = "<html><body>Not Found</body></html>";
+            return new ContentResult
+            {
+                Content = "Forbidden",
+                ContentType = "text/html; charset=utf-8",
+                StatusCode = 404
+            };
+        }
+    }
+}

--- a/Onspring.API.SDK.Tests/TestServer/Controllers/ErrorResponseController.cs
+++ b/Onspring.API.SDK.Tests/TestServer/Controllers/ErrorResponseController.cs
@@ -39,7 +39,7 @@ namespace Onspring.API.SDK.Tests.TestServer.Controllers
             var htmlContent = "<html><body>Not Found</body></html>";
             return new ContentResult
             {
-                Content = "Forbidden",
+                Content = htmlContent,
                 ContentType = "text/html; charset=utf-8",
                 StatusCode = 404
             };

--- a/Onspring.API.SDK.Tests/Tests/ApiResponseFactoryTests.cs
+++ b/Onspring.API.SDK.Tests/Tests/ApiResponseFactoryTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 using Onspring.API.SDK.Http;
 using Onspring.API.SDK.Json;
 using Onspring.API.SDK.Tests.Infrastructure;

--- a/Onspring.API.SDK.Tests/Tests/ApiResponseFactoryTests.cs
+++ b/Onspring.API.SDK.Tests/Tests/ApiResponseFactoryTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Onspring.API.SDK.Http;
+using Onspring.API.SDK.Json;
+using Onspring.API.SDK.Tests.Infrastructure;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading.Tasks;
+using HttpClientFactory = Onspring.API.SDK.Tests.Infrastructure.Http.HttpClientFactory;
+
+namespace Onspring.API.SDK.Tests.Tests
+{
+    [TestClass, ExcludeFromCodeCoverage]
+    public class ApiResponseFactoryTests
+    {
+        private static OnspringClient _apiClient;
+        private static HttpClient _httpClient;
+
+        [ClassInitialize]
+        public static void ClassInit(TestContext testContext)
+        {
+            var testConfiguration = TestConfiguration.LoadFromContext(testContext);
+            _httpClient = HttpClientFactory.GetHttpClient(testConfiguration);
+            _apiClient = new OnspringClient(testConfiguration.ApiKey, _httpClient);
+        }
+
+        [TestMethod]
+        public async Task GetApiResponse_WithNonJsonUnauthorizedResponse_DoesNotThrowJsonReaderException()
+        {
+            var requestUri = new Uri(_httpClient.BaseAddress, "errorresponse/non-json-unauthorized");
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var httpResponse = await _httpClient.SendAsync(request);
+
+            var jsonSerializer = JsonSerializerFactory.GetDefaultSerializer();
+
+            await ApiResponseFactory.GetApiResponseAsync(httpResponse, jsonSerializer);
+        }
+
+        [TestMethod]
+        public async Task GetApiResponse_WithNonJsonForbiddenResponse_DoesNotThrowJsonReaderException()
+        {
+            var requestUri = new Uri(_httpClient.BaseAddress, "errorresponse/non-json-forbidden");
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var httpResponse = await _httpClient.SendAsync(request);
+
+            var jsonSerializer = JsonSerializerFactory.GetDefaultSerializer();
+
+            await ApiResponseFactory.GetApiResponseAsync(httpResponse, jsonSerializer);
+        }
+
+        [TestMethod]
+        public async Task GetApiResponse_WithNonJsonNotFoundResponse_DoesNotThrowJsonReaderException()
+        {
+            var requestUri = new Uri(_httpClient.BaseAddress, "errorresponse/non-json-not-found");
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var httpResponse = await _httpClient.SendAsync(request);
+            var jsonSerializer = JsonSerializerFactory.GetDefaultSerializer();
+
+            await ApiResponseFactory.GetApiResponseAsync(httpResponse, jsonSerializer);
+        }
+    }
+}

--- a/Onspring.API.SDK/Http/ApiResponseFactory.cs
+++ b/Onspring.API.SDK/Http/ApiResponseFactory.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
-using Onspring.API.SDK.Extensions;
-using Onspring.API.SDK.Models;
-using System.Net;
+﻿using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Onspring.API.SDK.Extensions;
+using Onspring.API.SDK.Models;
 
 namespace Onspring.API.SDK.Http
 {
@@ -63,7 +63,11 @@ namespace Onspring.API.SDK.Http
         internal static async Task<string> TryGetMessageAsync(HttpResponseMessage httpResponse, JsonSerializer jsonSerializer)
         {
             var message = string.Empty;
-            if (httpResponse.StatusCode == HttpStatusCode.Unauthorized || httpResponse.StatusCode == HttpStatusCode.Forbidden || httpResponse.StatusCode == HttpStatusCode.NotFound)
+
+            if (
+                (httpResponse.StatusCode == HttpStatusCode.Unauthorized || httpResponse.StatusCode == HttpStatusCode.Forbidden || httpResponse.StatusCode == HttpStatusCode.NotFound) &&
+                IsJsonContentType(httpResponse.Content.Headers.ContentType?.MediaType)
+            )
             {
                 var messageResponse = await httpResponse.Content.ReadAsJsonAsync<MessageResponse>(jsonSerializer);
                 message = messageResponse?.Message;
@@ -72,7 +76,23 @@ namespace Onspring.API.SDK.Http
             {
                 message = await httpResponse.Content.ReadAsStringAsync();
             }
+
             return message ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Determines if the provided media type indicates JSON content.
+        /// </summary>
+        /// <param name="mediaType"></param>
+        /// <returns></returns>
+        private static bool IsJsonContentType(string mediaType)
+        {
+            if (string.IsNullOrEmpty(mediaType))
+            {
+                return false;
+            }
+
+            return mediaType.IndexOf("application/json", System.StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 }

--- a/Onspring.API.SDK/Onspring.API.SDK.csproj
+++ b/Onspring.API.SDK/Onspring.API.SDK.csproj
@@ -14,10 +14,15 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageTags>Onspring; Onspring Technologies; Onspring SDK; Onspring API</PackageTags>
 	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+  </ItemGroup>
 
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary

The PR addresses a bug fix for validating content types before deserializing HTTP error responses:

**Key Changes:**
- **Core Fix**: Added `IsJsonContentType()` validation method to check Content-Type headers before JSON deserialization
- **New Tests**: Added `ApiResponseFactoryTests` with 3 test cases for non-JSON error responses
- **Test Infrastructure**: Created `ErrorResponseController` to simulate HTML error responses (401, 403, 404)
- **Config**: Updated `.csproj` to allow test assembly access to internal SDK types

**Impact**: No breaking changes, fully backward compatible.

closes #21 